### PR TITLE
Add `Ring`, `Tube`, and `Torus` shapes

### DIFF
--- a/Sources/SwiftSCAD/Shapes/2D/Ring.swift
+++ b/Sources/SwiftSCAD/Shapes/2D/Ring.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// A hollow, two-dimensional circle.
+public struct Ring: Shape2D {
+	private let outerDiameter: Double
+	private let innerDiameter: Double
+
+	public init(outerDiameter: Double, innerDiameter: Double) {
+		precondition(outerDiameter > innerDiameter, "The outer diameter of the ring must be greater than the inner diameter to allow for a hole")
+		precondition(innerDiameter > 0.0, "The inner diameter must be positive")
+		precondition(outerDiameter > 0.0, "The outer diameter must be positive")
+
+		self.outerDiameter = outerDiameter
+		self.innerDiameter = innerDiameter
+	}
+
+	public init(outerRadius: Double, innerRadius: Double) {
+		self.init(outerDiameter: outerRadius * 2.0, innerDiameter: innerRadius * 2.0)
+	}
+
+	public init(outerDiameter: Double, thickness: Double) {
+		precondition(outerDiameter > thickness * 2.0, "The outer diameter must be greater than twice the thickness to allow for a hole")
+		self.init(outerDiameter: outerDiameter, innerDiameter: outerDiameter - thickness * 2.0)
+	}
+
+	public init(innerDiameter: Double, thickness: Double) {
+		self.init(outerDiameter: innerDiameter + thickness * 2.0, innerDiameter: innerDiameter)
+	}
+
+	public init(outerRadius: Double, thickness: Double) {
+		precondition(outerRadius > thickness, "The outer radius must be greater than the thickness to allow for a hole")
+		self.init(outerDiameter: outerRadius * 2.0, thickness: thickness)
+	}
+
+	public init(innerRadius: Double, thickness: Double) {
+		self.init(innerDiameter: innerRadius * 2.0, thickness: thickness)
+	}
+
+	public var body: Geometry2D {
+		Circle(diameter: outerDiameter)
+			.subtracting {
+				Circle(diameter: innerDiameter)
+			}
+	}
+}

--- a/Sources/SwiftSCAD/Shapes/3D/Torus.swift
+++ b/Sources/SwiftSCAD/Shapes/3D/Torus.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// A three-dimensional donut shape formed by revolving a circle about the Z axis.
+public struct Torus: Shape3D {
+	/// The radius of the tube.
+	private let minorRadius: Double
+
+	/// The distance from the center of the tube to the center of the torus.
+	private let majorRadius: Double
+
+	public init(minorRadius: Double, majorRadius: Double) {
+		precondition(majorRadius >= minorRadius, "The major radius must be greater than or equal to the minor radius")
+		self.minorRadius = minorRadius
+		self.majorRadius = majorRadius
+	}
+
+	public init(innerDiameter: Double, outerDiameter: Double) {
+		precondition(outerDiameter > innerDiameter, "The outer diameter must be greater than the inner diameter")
+		let tubeDiameter = (outerDiameter - innerDiameter) / 2.0
+		self.init(minorRadius: tubeDiameter / 2.0, majorRadius: innerDiameter / 2.0 + tubeDiameter / 2.0)
+	}
+
+	public init(innerDiameter: Double, tubeRadius: Double) {
+		self.init(minorRadius: tubeRadius, majorRadius: innerDiameter / 2.0 + tubeRadius)
+	}
+
+	public init(innerDiameter: Double, tubeDiameter: Double) {
+		self.init(minorRadius: tubeDiameter / 2.0, majorRadius: innerDiameter / 2.0 + tubeDiameter / 2.0)
+	}
+
+	public init(outerDiameter: Double, tubeRadius: Double) {
+		precondition(outerDiameter >= tubeRadius * 4.0, "The outer diameter must be at least four times as large as the tube radius")
+		self.init(minorRadius: tubeRadius, majorRadius: outerDiameter / 2.0 - tubeRadius)
+	}
+
+	public init(outerDiameter: Double, tubeDiameter: Double) {
+		precondition(outerDiameter >= tubeDiameter * 2.0, "The outer diameter must be at least twice as large as the tube diameter")
+		self.init(minorRadius: tubeDiameter / 2.0, majorRadius: outerDiameter / 2.0 - tubeDiameter / 2.0)
+	}
+
+	public var body: Geometry3D {
+		Circle(radius: minorRadius)
+			.translated(x: majorRadius, y: minorRadius)
+			.extruded(angles: 0°..<360°)
+	}
+}

--- a/Sources/SwiftSCAD/Shapes/3D/Tube.swift
+++ b/Sources/SwiftSCAD/Shapes/3D/Tube.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// A hollow, three-dimensional cylinder with a fixed inner and outer diameter.
+public struct Tube: Shape3D {
+	private let outerDiameter: Double
+	private let innerDiameter: Double
+	private let height: Double
+
+	public init(outerDiameter: Double, innerDiameter: Double, height: Double) {
+		precondition(outerDiameter > innerDiameter, "The outer diameter of the ring must be greater than the inner diameter to allow for a hole")
+		precondition(innerDiameter > 0.0, "The inner diameter must be positive")
+		precondition(outerDiameter > 0.0, "The outer diameter must be positive")
+
+		self.outerDiameter = outerDiameter
+		self.innerDiameter = innerDiameter
+		self.height = height
+	}
+
+	public init(outerRadius: Double, innerRadius: Double, height: Double) {
+		self.init(outerDiameter: outerRadius * 2.0, innerDiameter: innerRadius * 2.0, height: height)
+	}
+
+	public init(outerDiameter: Double, thickness: Double, height: Double) {
+		precondition(outerDiameter > thickness * 2.0, "The outer diameter must be greater than twice the thickness to allow for a hole")
+		self.init(outerDiameter: outerDiameter, innerDiameter: outerDiameter - thickness * 2.0, height: height)
+	}
+
+	public init(innerDiameter: Double, thickness: Double, height: Double) {
+		self.init(outerDiameter: innerDiameter + thickness * 2.0, innerDiameter: innerDiameter, height: height)
+	}
+
+	public init(outerRadius: Double, thickness: Double, height: Double) {
+		precondition(outerRadius > thickness, "The outer diameter must be greater than the thickness to allow for a hole")
+		self.init(outerDiameter: outerRadius * 2.0, thickness: thickness, height: height)
+	}
+
+	public init(innerRadius: Double, thickness: Double, height: Double) {
+		self.init(innerDiameter: innerRadius * 2.0, thickness: thickness, height: height)
+	}
+
+	public var body: Geometry3D {
+		Ring(outerDiameter: outerDiameter, innerDiameter: innerDiameter)
+			.extruded(height: height)
+	}
+}


### PR DESCRIPTION
This pull request adds three shapes that I believe most (or at least a few 🙂) people would expect to find in the library:
* **Ring**, a hollow, two-dimensional circle.
* **Tube**, a hollow, three-dimensional cylinder with a fixed inner and outer diameter.
* **Torus**, a three-dimensional donut shape formed by revolving a circle about the Z axis.

### Example usage
```swift
Union {
    Ring(innerDiameter: 10.0, thickness: 5.0)
        .translated(x: -25.0)
        .extruded(height: 5.0)

    Tube(innerDiameter: 10.0, thickness: 5.0, height: 5.0)

    Torus(innerDiameter: 10.0, tubeDiameter: 5.0)
        .translated(x: 25.0)
}.save(to: "/tmp/model.scad")
```

<img width="1040" alt="Screenshot 2021-08-24 at 21 02 34" src="https://user-images.githubusercontent.com/144932/130674935-1edc3304-05fe-49c4-88e0-1cf28b45624c.png">

